### PR TITLE
refactor: add 'self' namespace before custom options

### DIFF
--- a/homes/default.nix
+++ b/homes/default.nix
@@ -30,10 +30,7 @@ let
           programs.home-manager.enable = true;
         }
         (CONFIG_PATH + "/home.nix")
-        self.homeModules.cli
-        self.homeModules.gui
-        self.homeModules.styling
-        self.homeModules.wm
+        self.homeModules.all
       ];
 
       extraSpecialArgs = {
@@ -54,7 +51,7 @@ let
     in
     {
       flake.homeConfigurations."${username}@${hostName}" = homeConfiguration;
-      # flake.checks.${system}.${hostName} = homeConfigurations.config.system.build.toplevel;
+      # flake.checks.${system}.${hostName} = homeConfigurations.activationPackage;
     };
 in
 {

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -26,9 +26,7 @@ let
 
       modules = [
         (CONFIG_PATH + "/configuration.nix")
-        self.nixosModules.defaults
-        self.nixosModules.nas
-        self.nixosModules.qmk
+        self.nixosModules.all
       ];
 
       specialArgs = {

--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -8,6 +8,8 @@ with lib;
     ./hardware-configuration.nix
   ];
 
+  self.all.enable = true;
+
   #! This value determines the NixOS release from which the default
   #! settings for stateful data, like file locations and database versions
   #! on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/thinkpad/home.nix
+++ b/hosts/thinkpad/home.nix
@@ -7,12 +7,6 @@ let
   inherit (inputs.tygo-van-den-hurk-dotfiles.packages.${system}) preview;
 in
 {
-  cli.enable = true;
-  cli.miscellaneous.zellij.enable = false;
-  gui.enable = true;
-  styling.enable = true;
-  wm.enable = true;
-
   home.username = "tygo";
   home.homeDirectory = "/home/tygo";
   home.stateVersion = "25.05";
@@ -20,7 +14,10 @@ in
     preview
   ];
 
-  wm.monitors."builtin display" = {
+  self.all.enable = true;
+  self.cli.miscellaneous.zellij.enable = false;
+
+  self.wm.monitors."builtin display" = {
     primary = true;
     adapter = "eDP-1";
     refresh-rate = 60;
@@ -30,7 +27,7 @@ in
     position.horizontal = 0;
   };
 
-  wm.monitors."HDMI port" = {
+  self.wm.monitors."HDMI port" = {
     primary = true;
     adapter = "HDMI-1";
     refresh-rate = 60;
@@ -40,7 +37,7 @@ in
     position.horizontal = 0;
   };
 
-  wm.monitors."USB-C" = {
+  self.wm.monitors."USB-C" = {
     primary = true;
     adapter = "DP-1";
     refresh-rate = 60;
@@ -50,6 +47,6 @@ in
 
   # TEMP:
 
-  gui.messengers.thunderbird.enable = false;
+  self.gui.messengers.thunderbird.enable = false;
   programs.rofi.enable = true;
 }

--- a/modules/home/all/default.nix
+++ b/modules/home/all/default.nix
@@ -1,0 +1,40 @@
+{ inputs, ... }:
+let
+  namespace = "self";
+  module = "all";
+in
+{
+  flake.homeModules.${module} =
+    {
+      config,
+      lib,
+      ...
+    }:
+    with lib;
+    let
+      cfg = config.${namespace}.${module};
+    in
+    {
+      options.${namespace}.${module} = with types; {
+        enable = mkOption {
+          description = "Whether to enable all modules under the self namespace.";
+          default = false;
+          type = bool;
+        };
+      };
+
+      config.${namespace} = mkIf cfg.enable {
+        cli.enable = mkDefault true;
+        gui.enable = mkDefault true;
+        styling.enable = mkDefault true;
+        wm.enable = mkDefault true;
+      };
+
+      imports = with inputs.self.homeModules; [
+        cli
+        gui
+        styling
+        wm
+      ];
+    };
+}

--- a/modules/home/cli/default.nix
+++ b/modules/home/cli/default.nix
@@ -1,5 +1,6 @@
 { inputs, ... }:
 let
+  namespace = "self";
   module = "cli";
 in
 {
@@ -12,10 +13,10 @@ in
     }:
     with lib;
     let
-      cfg = config.${module};
+      cfg = config.${namespace}.${module};
     in
     {
-      options.${module} = with types; {
+      options.${namespace}.${module} = with types; {
         enable = mkOption {
           description = "Whether to enable CLI applications and terminal based tools.";
           default = false;

--- a/modules/home/cli/editors/default.nix
+++ b/modules/home/cli/editors/default.nix
@@ -5,14 +5,15 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "editors";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/editors/glow.nix
+++ b/modules/home/cli/editors/glow.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "editors";
   program = "glow";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/editors/micro.nix
+++ b/modules/home/cli/editors/micro.nix
@@ -6,17 +6,18 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "editors";
   program = "micro";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
 
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 

--- a/modules/home/cli/file-managers/default.nix
+++ b/modules/home/cli/file-managers/default.nix
@@ -5,14 +5,15 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/file-managers/ranger.nix
+++ b/modules/home/cli/file-managers/ranger.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "ranger";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/file-managers/yazi/default.nix
+++ b/modules/home/cli/file-managers/yazi/default.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/file-managers/yazi/flavors.nix
+++ b/modules/home/cli/file-managers/yazi/flavors.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.flavors = mkIf cfg.enable {

--- a/modules/home/cli/file-managers/yazi/keymap.nix
+++ b/modules/home/cli/file-managers/yazi/keymap.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.keymap = mkIf cfg.enable {

--- a/modules/home/cli/file-managers/yazi/plugins/git/default.nix
+++ b/modules/home/cli/file-managers/yazi/plugins/git/default.nix
@@ -6,17 +6,18 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
   plugin = "git";
-  cfg = config.${type}.${category}.${program}.plugins.${plugin};
+  cfg = config.${namespace}.${type}.${category}.${program}.plugins.${plugin};
 in
 {
-  options.${type}.${category}.${program}.plugins.${plugin} = with types; {
+  options.${namespace}.${type}.${category}.${program}.plugins.${plugin} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s ${plugin} plugin.";
-      default = config.${type}.${category}.${program}.enable && config.programs.git.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable && config.programs.git.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/file-managers/yazi/plugins/lazygit/default.nix
+++ b/modules/home/cli/file-managers/yazi/plugins/lazygit/default.nix
@@ -6,17 +6,19 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
   plugin = "lazygit";
-  cfg = config.${type}.${category}.${program}.plugins.${plugin};
+  cfg = config.${namespace}.${type}.${category}.${program}.plugins.${plugin};
 in
 {
-  options.${type}.${category}.${program}.plugins.${plugin} = with types; {
+  options.${namespace}.${type}.${category}.${program}.plugins.${plugin} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s ${plugin} plugin.";
-      default = config.${type}.${category}.${program}.enable && config.programs.${plugin}.enable;
+      default =
+        config.${namespace}.${type}.${category}.${program}.enable && config.programs.${plugin}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/file-managers/yazi/plugins/ouch/default.nix
+++ b/modules/home/cli/file-managers/yazi/plugins/ouch/default.nix
@@ -6,46 +6,49 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
   plugin = "ouch";
 in
 {
-  options.${type}.${category}.${program}.plugins.${plugin} = with types; {
+  options.${namespace}.${type}.${category}.${program}.plugins.${plugin} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s ${plugin} plugin.";
-      default = config.${type}.${category}.${program}.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable;
       type = bool;
     };
   };
 
-  config.home = mkIf config.${type}.${category}.${program}.plugins.${plugin}.enable {
+  config.home = mkIf config.${namespace}.${type}.${category}.${program}.plugins.${plugin}.enable {
     packages = [ pkgs.${plugin} ];
   };
 
-  config.programs.${program} = mkIf config.${type}.${category}.${program}.plugins.${plugin}.enable {
-    plugins.${plugin} = mkDefault pkgs.yaziPlugins.${plugin};
-    initLua = mkDefault (builtins.readFile ./init.lua);
-    settings.opener.extract = [
+  config.programs.${program} =
+    mkIf config.${namespace}.${type}.${category}.${program}.plugins.${plugin}.enable
       {
-        run = "ouch d -y %*";
-        desc = "Extract here with ouch";
-        for = "windows";
-      }
-      {
-        run = "ouch d -y \"\$@\"";
-        desc = "Extract here with ouch";
-        for = "unix";
-      }
-    ];
+        plugins.${plugin} = mkDefault pkgs.yaziPlugins.${plugin};
+        initLua = mkDefault (builtins.readFile ./init.lua);
+        settings.opener.extract = [
+          {
+            run = "ouch d -y %*";
+            desc = "Extract here with ouch";
+            for = "windows";
+          }
+          {
+            run = "ouch d -y \"\$@\"";
+            desc = "Extract here with ouch";
+            for = "unix";
+          }
+        ];
 
-    keymap.mgr.prepend_keymap = [
-      {
-        on = [ "C" ];
-        run = "plugin ouch";
-        desc = "Compress with ouch";
-      }
-    ];
-  };
+        keymap.mgr.prepend_keymap = [
+          {
+            on = [ "C" ];
+            run = "plugin ouch";
+            desc = "Compress with ouch";
+          }
+        ];
+      };
 }

--- a/modules/home/cli/file-managers/yazi/plugins/restore/default.nix
+++ b/modules/home/cli/file-managers/yazi/plugins/restore/default.nix
@@ -6,37 +6,40 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
   plugin = "restore";
 in
 {
-  options.${type}.${category}.${program}.plugins.${plugin} = with types; {
+  options.${namespace}.${type}.${category}.${program}.plugins.${plugin} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s ${plugin} plugin.";
-      default = config.${type}.${category}.${program}.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable;
       type = bool;
     };
   };
 
-  config.programs.${program} = mkIf config.${type}.${category}.${program}.plugins.${plugin}.enable {
-    plugins.${plugin} = mkDefault pkgs.yaziPlugins.${plugin};
-    initLua = mkDefault (builtins.readFile ./init.lua);
-    settings.mgr.keymap = [
+  config.programs.${program} =
+    mkIf config.${namespace}.${type}.${category}.${program}.plugins.${plugin}.enable
       {
-        on = "u";
-        run = "plugin restore";
-        desc = "Restore last deleted files/folders";
-      }
-      {
-        on = [
-          "d"
-          "u"
+        plugins.${plugin} = mkDefault pkgs.yaziPlugins.${plugin};
+        initLua = mkDefault (builtins.readFile ./init.lua);
+        settings.mgr.keymap = [
+          {
+            on = "u";
+            run = "plugin restore";
+            desc = "Restore last deleted files/folders";
+          }
+          {
+            on = [
+              "d"
+              "u"
+            ];
+            run = "plugin restore";
+            desc = "Restore last deleted files/folders";
+          }
         ];
-        run = "plugin restore";
-        desc = "Restore last deleted files/folders";
-      }
-    ];
-  };
+      };
 }

--- a/modules/home/cli/file-managers/yazi/plugins/starship/default.nix
+++ b/modules/home/cli/file-managers/yazi/plugins/starship/default.nix
@@ -6,22 +6,25 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
   plugin = "starship";
 in
 {
-  options.${type}.${category}.${program}.plugins.${plugin} = with types; {
+  options.${namespace}.${type}.${category}.${program}.plugins.${plugin} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s ${plugin} plugin.";
-      default = config.${type}.${category}.${program}.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable;
       type = bool;
     };
   };
 
-  config.programs.${program} = mkIf config.${type}.${category}.${program}.plugins.${plugin}.enable {
-    plugins.${plugin} = mkDefault pkgs.yaziPlugins.${plugin};
-    initLua = mkDefault (builtins.readFile ./init.lua);
-  };
+  config.programs.${program} =
+    mkIf config.${namespace}.${type}.${category}.${program}.plugins.${plugin}.enable
+      {
+        plugins.${plugin} = mkDefault pkgs.yaziPlugins.${plugin};
+        initLua = mkDefault (builtins.readFile ./init.lua);
+      };
 }

--- a/modules/home/cli/file-managers/yazi/plugins/sudo/default.nix
+++ b/modules/home/cli/file-managers/yazi/plugins/sudo/default.nix
@@ -6,100 +6,103 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
   plugin = "sudo";
 in
 {
-  options.${type}.${category}.${program}.plugins.${plugin} = with types; {
+  options.${namespace}.${type}.${category}.${program}.plugins.${plugin} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s ${plugin} plugin.";
-      default = config.${type}.${category}.${program}.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable;
       type = bool;
     };
   };
 
-  config.programs.${program} = mkIf config.${type}.${category}.${program}.plugins.${plugin}.enable {
-    plugins.${plugin} = mkDefault pkgs.yaziPlugins.${plugin};
-    initLua = mkDefault (builtins.readFile ./init.lua);
-    keymap.mgr.keymap = [
+  config.programs.${program} =
+    mkIf config.${namespace}.${type}.${category}.${program}.plugins.${plugin}.enable
       {
-        on = [
-          "R"
-          "p"
-          "p"
+        plugins.${plugin} = mkDefault pkgs.yaziPlugins.${plugin};
+        initLua = mkDefault (builtins.readFile ./init.lua);
+        keymap.mgr.keymap = [
+          {
+            on = [
+              "R"
+              "p"
+              "p"
+            ];
+            run = "plugin sudo -- paste";
+            desc = "sudo paste";
+          }
+          {
+            on = [
+              "R"
+              "P"
+            ];
+            run = "plugin sudo -- paste --force";
+            desc = "sudo paste";
+          }
+          {
+            on = [
+              "R"
+              "r"
+            ];
+            run = "plugin sudo -- rename";
+            desc = "sudo rename";
+          }
+          {
+            on = [
+              "R"
+              "p"
+              "l"
+            ];
+            run = "plugin sudo -- link";
+            desc = "sudo link";
+          }
+          {
+            on = [
+              "R"
+              "p"
+              "r"
+            ];
+            run = "plugin sudo -- link --relative";
+            desc = "sudo link relative path";
+          }
+          {
+            on = [
+              "R"
+              "p"
+              "L"
+            ];
+            run = "plugin sudo -- hardlink";
+            desc = "sudo hardlink";
+          }
+          {
+            on = [
+              "R"
+              "a"
+            ];
+            run = "plugin sudo -- create";
+            desc = "sudo create";
+          }
+          {
+            on = [
+              "R"
+              "d"
+            ];
+            run = "plugin sudo -- remove";
+            desc = "sudo trash";
+          }
+          {
+            on = [
+              "R"
+              "D"
+            ];
+            run = "plugin sudo -- remove --permanently";
+            desc = "sudo delete";
+          }
         ];
-        run = "plugin sudo -- paste";
-        desc = "sudo paste";
-      }
-      {
-        on = [
-          "R"
-          "P"
-        ];
-        run = "plugin sudo -- paste --force";
-        desc = "sudo paste";
-      }
-      {
-        on = [
-          "R"
-          "r"
-        ];
-        run = "plugin sudo -- rename";
-        desc = "sudo rename";
-      }
-      {
-        on = [
-          "R"
-          "p"
-          "l"
-        ];
-        run = "plugin sudo -- link";
-        desc = "sudo link";
-      }
-      {
-        on = [
-          "R"
-          "p"
-          "r"
-        ];
-        run = "plugin sudo -- link --relative";
-        desc = "sudo link relative path";
-      }
-      {
-        on = [
-          "R"
-          "p"
-          "L"
-        ];
-        run = "plugin sudo -- hardlink";
-        desc = "sudo hardlink";
-      }
-      {
-        on = [
-          "R"
-          "a"
-        ];
-        run = "plugin sudo -- create";
-        desc = "sudo create";
-      }
-      {
-        on = [
-          "R"
-          "d"
-        ];
-        run = "plugin sudo -- remove";
-        desc = "sudo trash";
-      }
-      {
-        on = [
-          "R"
-          "D"
-        ];
-        run = "plugin sudo -- remove --permanently";
-        desc = "sudo delete";
-      }
-    ];
-  };
+      };
 }

--- a/modules/home/cli/file-managers/yazi/settings.nix
+++ b/modules/home/cli/file-managers/yazi/settings.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings = mkIf cfg.enable {

--- a/modules/home/cli/file-managers/yazi/theme.nix
+++ b/modules/home/cli/file-managers/yazi/theme.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "file-managers";
   program = "yazi";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.theme = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/bat.nix
+++ b/modules/home/cli/miscellaneous/bat.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "bat";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/miscellaneous/btop.nix
+++ b/modules/home/cli/miscellaneous/btop.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "btop";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/miscellaneous/default.nix
+++ b/modules/home/cli/miscellaneous/default.nix
@@ -5,14 +5,15 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/miscellaneous/direnv.nix
+++ b/modules/home/cli/miscellaneous/direnv.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "direnv";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/miscellaneous/eza.nix
+++ b/modules/home/cli/miscellaneous/eza.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "eza";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };
@@ -38,7 +39,7 @@ in
 
   config.home.shellAliases = mkIf cfg.enable {
     la = mkDefault "${program} --group-directories-first --all";
-    ll = mkDefault "${program} --group-directories-first --long ";
+    ll = mkDefault "${program} --group-directories-first --long";
     lla = mkDefault "${program} --group-directories-first --long --all";
     ls = mkDefault "${program} --group-directories-first --long";
     lt = mkDefault "${program} --group-directories-first --tree --all";

--- a/modules/home/cli/miscellaneous/fzf.nix
+++ b/modules/home/cli/miscellaneous/fzf.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "fzf";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/miscellaneous/onefetch.nix
+++ b/modules/home/cli/miscellaneous/onefetch.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "onefetch";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/miscellaneous/slack-term.nix
+++ b/modules/home/cli/miscellaneous/slack-term.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "slack-term";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 

--- a/modules/home/cli/miscellaneous/starship/c.nix
+++ b/modules/home/cli/miscellaneous/starship/c.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."c" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/character.nix
+++ b/modules/home/cli/miscellaneous/starship/character.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."character" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/cpp.nix
+++ b/modules/home/cli/miscellaneous/starship/cpp.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."cpp" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/default.nix
+++ b/modules/home/cli/miscellaneous/starship/default.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/miscellaneous/starship/directory.nix
+++ b/modules/home/cli/miscellaneous/starship/directory.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."directory" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/git_branch.nix
+++ b/modules/home/cli/miscellaneous/starship/git_branch.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."git_branch" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/git_commit.nix
+++ b/modules/home/cli/miscellaneous/starship/git_commit.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."git_commit" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/git_metrics.nix
+++ b/modules/home/cli/miscellaneous/starship/git_metrics.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."git_metrics" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/git_state.nix
+++ b/modules/home/cli/miscellaneous/starship/git_state.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."git_state" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/git_status.nix
+++ b/modules/home/cli/miscellaneous/starship/git_status.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."git_status" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/hostname.nix
+++ b/modules/home/cli/miscellaneous/starship/hostname.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."hostname" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/nix_shell.nix
+++ b/modules/home/cli/miscellaneous/starship/nix_shell.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."nix_shell" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/nodejs.nix
+++ b/modules/home/cli/miscellaneous/starship/nodejs.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."nodejs" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/os.nix
+++ b/modules/home/cli/miscellaneous/starship/os.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."os" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/python.nix
+++ b/modules/home/cli/miscellaneous/starship/python.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."python" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/rust.nix
+++ b/modules/home/cli/miscellaneous/starship/rust.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."rust" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/time.nix
+++ b/modules/home/cli/miscellaneous/starship/time.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."time" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/typst.nix
+++ b/modules/home/cli/miscellaneous/starship/typst.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."typst" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/starship/username.nix
+++ b/modules/home/cli/miscellaneous/starship/username.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "starship";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.settings."username" = mkIf cfg.enable {

--- a/modules/home/cli/miscellaneous/zellij.nix
+++ b/modules/home/cli/miscellaneous/zellij.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "zellij";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/miscellaneous/zoxide.nix
+++ b/modules/home/cli/miscellaneous/zoxide.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "miscellaneous";
   program = "zoxide";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/processors/default.nix
+++ b/modules/home/cli/processors/default.nix
@@ -5,14 +5,15 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "processors";
   type = "cli";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/processors/jq.nix
+++ b/modules/home/cli/processors/jq.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "processors";
   program = "jq";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/processors/jqp.nix
+++ b/modules/home/cli/processors/jqp.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "processors";
   program = "jqp";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/processors/octave.nix
+++ b/modules/home/cli/processors/octave.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "processors";
   program = "octave";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/processors/qalc.nix
+++ b/modules/home/cli/processors/qalc.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "processors";
   program = "qalc";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };
@@ -25,7 +26,7 @@ in
       ${program}_function() {
         ${pkgs.libqalculate}/bin/${program} "$@"
         local status="$?"
-        set +f # enable globing
+        set +f # reenable globing
         return "$status"
       }
     '';
@@ -36,7 +37,7 @@ in
       ${program}_function() {
         ${pkgs.libqalculate}/bin/${program} "$@"
         local status="$?"
-        set +f # enable globing
+        set +f # reenable globing
         return "$status"
       }
     '';
@@ -47,7 +48,7 @@ in
       function ${program}_function
         ${pkgs.libqalculate}/bin/${program} "$@"
         set exit_code $status
-        set +f # enable globing
+        set +f # reenable globing
         return "$exit_code"
       end
     '';

--- a/modules/home/cli/shells/bash/default.nix
+++ b/modules/home/cli/shells/bash/default.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   program = "bash";
   category = "shells";
   type = "cli";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/shells/default.nix
+++ b/modules/home/cli/shells/default.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "shells";
   type = "cli";
-  cfg = config.${type}.${category};
+  cfg = config.${namespace}.${type}.${category};
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };
@@ -22,6 +23,6 @@ in
     clear = mkDefault "printf \"\\e[2J\\e[3J\\e[H\"";
     c = clear;
     ckear = clear;
-    ear = ":";
+    ear = "(exit $?)";
   };
 }

--- a/modules/home/cli/shells/fish.nix
+++ b/modules/home/cli/shells/fish.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   program = "fish";
   category = "shells";
   type = "cli";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/shells/nushell.nix
+++ b/modules/home/cli/shells/nushell.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   program = "nushell";
   category = "shells";
   type = "cli";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/shells/zsh.nix
+++ b/modules/home/cli/shells/zsh.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   program = "zsh";
   category = "shells";
   type = "cli";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/version-control/default.nix
+++ b/modules/home/cli/version-control/default.nix
@@ -5,14 +5,15 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "version-control";
   type = "cli";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/version-control/gh-dash.nix
+++ b/modules/home/cli/version-control/gh-dash.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "version-control";
   program = "gh-dash";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/version-control/gh.nix
+++ b/modules/home/cli/version-control/gh.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "version-control";
   program = "gh";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/version-control/git/default.nix
+++ b/modules/home/cli/version-control/git/default.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "version-control";
   program = "git";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/version-control/git/delta.nix
+++ b/modules/home/cli/version-control/git/delta.nix
@@ -5,17 +5,18 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "version-control";
   program = "git";
   helper = "delta";
-  cfg = config.${type}.${category}.${program}.${helper};
+  cfg = config.${namespace}.${type}.${category}.${program}.${helper};
 in
 {
-  options.${type}.${category}.${program}.${helper} = with types; {
+  options.${namespace}.${type}.${category}.${program}.${helper} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/cli/version-control/lazygit.nix
+++ b/modules/home/cli/version-control/lazygit.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "cli";
   category = "version-control";
   program = "lazygit";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -3,6 +3,7 @@
   # Do not import dynamically / recursively as they use different module systems.
   imports = [
     inputs.home-manager.flakeModules.home-manager
+    ./all
     ./cli
     ./gui
     ./styling

--- a/modules/home/gui/browsers/default.nix
+++ b/modules/home/gui/browsers/default.nix
@@ -5,14 +5,15 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/browsers/firefox/default.nix
+++ b/modules/home/gui/browsers/firefox/default.nix
@@ -6,17 +6,18 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
   program = "firefox";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
 
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 

--- a/modules/home/gui/browsers/firefox/policies.nix
+++ b/modules/home/gui/browsers/firefox/policies.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
   program = "firefox";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   # [See list of policies](https://mozilla.github.io/policy-templates/). Attribute set of (JSON value)

--- a/modules/home/gui/browsers/firefox/profiles/main/bookmarks.nix
+++ b/modules/home/gui/browsers/firefox/profiles/main/bookmarks.nix
@@ -5,11 +5,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
   program = "firefox";
   profile = "main";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.profiles.${profile}.bookmarks = mkIf cfg.enable {

--- a/modules/home/gui/browsers/firefox/profiles/main/containers.nix
+++ b/modules/home/gui/browsers/firefox/profiles/main/containers.nix
@@ -5,11 +5,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
   program = "firefox";
   profile = "main";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.profiles.${profile} = mkIf cfg.enable {

--- a/modules/home/gui/browsers/firefox/profiles/main/default.nix
+++ b/modules/home/gui/browsers/firefox/profiles/main/default.nix
@@ -5,11 +5,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
   program = "firefox";
   profile = "main";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.profiles.${profile} = mkIf cfg.enable {

--- a/modules/home/gui/browsers/firefox/profiles/main/extensions.nix
+++ b/modules/home/gui/browsers/firefox/profiles/main/extensions.nix
@@ -5,11 +5,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
   program = "firefox";
   profile = "main";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.profiles.${profile}.extensions = mkIf cfg.enable {

--- a/modules/home/gui/browsers/firefox/profiles/main/search.nix
+++ b/modules/home/gui/browsers/firefox/profiles/main/search.nix
@@ -6,11 +6,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
   program = "firefox";
   profile = "main";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.profiles.${profile}.search = mkIf cfg.enable {

--- a/modules/home/gui/browsers/firefox/profiles/main/settings.nix
+++ b/modules/home/gui/browsers/firefox/profiles/main/settings.nix
@@ -5,11 +5,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
   program = "firefox";
   profile = "main";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config.programs.${program}.profiles.${profile}.settings = mkIf cfg.enable {

--- a/modules/home/gui/browsers/firefox/profiles/stylix.nix
+++ b/modules/home/gui/browsers/firefox/profiles/stylix.nix
@@ -5,10 +5,11 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "browsers";
   program = "firefox";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
   config = mkIf (cfg.enable && config ? stylix) {

--- a/modules/home/gui/default.nix
+++ b/modules/home/gui/default.nix
@@ -1,16 +1,21 @@
 { inputs, ... }:
 let
+  namespace = "self";
   module = "gui";
 in
 {
   flake.homeModules.${module} =
     {
       lib,
+      config,
       ...
     }:
     with lib;
+    let
+      cfg = config.${namespace}.${module};
+    in
     {
-      options.${module} = with types; {
+      options.${namespace}.${module} = with types; {
         enable = mkOption {
           description = "Whether to enable GUI applications and tools.";
           default = false;
@@ -18,9 +23,11 @@ in
         };
       };
 
-      # Bug fixes: https://github.com/alacritty/alacritty/issues/5101;
-      config.home.sessionVariables.WINIT_X11_SCALE_FACTOR = 1;
-      config.xdg.mimeApps.enable = true;
+      config = mkIf cfg.enable {
+        # Bug fixes: https://github.com/alacritty/alacritty/issues/5101;
+        home.sessionVariables.WINIT_X11_SCALE_FACTOR = mkDefault 1;
+        xdg.mimeApps.enable = mkDefault true;
+      };
 
       imports = inputs.self.lib.import-recursively {
         base = ./.;

--- a/modules/home/gui/file-viewers/default.nix
+++ b/modules/home/gui/file-viewers/default.nix
@@ -5,14 +5,15 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "file-viewers";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/file-viewers/mpv.nix
+++ b/modules/home/gui/file-viewers/mpv.nix
@@ -5,17 +5,18 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "file-viewers";
   program = "mpv";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
 
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 

--- a/modules/home/gui/file-viewers/sxiv.nix
+++ b/modules/home/gui/file-viewers/sxiv.nix
@@ -6,17 +6,18 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "file-viewers";
   program = "sxiv";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
 
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 

--- a/modules/home/gui/file-viewers/thunar.nix
+++ b/modules/home/gui/file-viewers/thunar.nix
@@ -6,17 +6,18 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "file-viewers";
   program = "thunar";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
 
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 

--- a/modules/home/gui/file-viewers/zathura.nix
+++ b/modules/home/gui/file-viewers/zathura.nix
@@ -5,23 +5,24 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "file-viewers";
   program = "zathura";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
 
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 
     mkDefault = mkOption {
       description = "Whether to make ${program} the default program to open its file type.";
-      default = config.${type}.${category}.${program}.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/messengers/default.nix
+++ b/modules/home/gui/messengers/default.nix
@@ -5,14 +5,15 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "messengers";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/messengers/discord.nix
+++ b/modules/home/gui/messengers/discord.nix
@@ -6,16 +6,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "messengers";
   program = "discord";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/messengers/signal.nix
+++ b/modules/home/gui/messengers/signal.nix
@@ -6,22 +6,23 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "messengers";
   program = "signal";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 
     mkDefault = mkOption {
       description = "Whether to make ${program} the default program to open its file type.";
-      default = config.${type}.${category}.${program}.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/messengers/telegram.nix
+++ b/modules/home/gui/messengers/telegram.nix
@@ -6,22 +6,23 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "messengers";
   program = "telegram";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 
     mkDefault = mkOption {
       description = "Whether to make ${program} the default program to open its file type.";
-      default = config.${type}.${category}.${program}.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/messengers/thunderbird.nix
+++ b/modules/home/gui/messengers/thunderbird.nix
@@ -5,22 +5,23 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "messengers";
   program = "thunderbird";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 
     mkDefault = mkOption {
       description = "Whether to make ${program} the default program to open its file type.";
-      default = config.${type}.${category}.${program}.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/messengers/whatsapp.nix
+++ b/modules/home/gui/messengers/whatsapp.nix
@@ -7,16 +7,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "messengers";
   program = "whatsapp";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/terminals/alacritty.nix
+++ b/modules/home/gui/terminals/alacritty.nix
@@ -5,16 +5,17 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "terminals";
   program = "alacritty";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/terminals/default.nix
+++ b/modules/home/gui/terminals/default.nix
@@ -5,14 +5,15 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "terminals";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/gui/terminals/kitty.nix
+++ b/modules/home/gui/terminals/kitty.nix
@@ -7,22 +7,23 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "gui";
   category = "terminals";
   program = "kitty";
-  cfg = config.${type}.${category}.${program};
+  cfg = config.${namespace}.${type}.${category}.${program};
 in
 {
-  options.${type}.${category}.${program} = with types; {
+  options.${namespace}.${type}.${category}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.${category}.enable;
+      default = config.${namespace}.${type}.${category}.enable;
       type = bool;
     };
 
     mkDefault = mkOption {
       description = "Whether to make ${program} the default program to open its file type.";
-      default = config.${type}.${category}.${program}.enable;
+      default = config.${namespace}.${type}.${category}.${program}.enable;
       type = bool;
     };
   };

--- a/modules/home/styling/default.nix
+++ b/modules/home/styling/default.nix
@@ -1,5 +1,6 @@
 { inputs, ... }:
 let
+  namespace = "self";
   module = "styling";
 in
 {
@@ -11,10 +12,10 @@ in
     }:
     with lib;
     let
-      cfg = config.${module};
+      cfg = config.${namespace}.${module};
     in
     {
-      options.${module} = with types; {
+      options.${namespace}.${module} = with types; {
         enable = mkOption {
           description = "Whether to enable styling of all tools.";
           default = false;

--- a/modules/home/styling/fonts.nix
+++ b/modules/home/styling/fonts.nix
@@ -6,15 +6,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "fonts";
   type = "styling";
-  cfg = config.${type}.${category};
+  cfg = config.${namespace}.${type}.${category};
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable default config for the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/styling/gtk.nix
+++ b/modules/home/styling/gtk.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "gtk";
   type = "styling";
-  cfg = config.${type}.${category};
+  cfg = config.${namespace}.${type}.${category};
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable styling using the ${category} framework.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/styling/qt.nix
+++ b/modules/home/styling/qt.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "qt";
   type = "styling";
-  cfg = config.${type}.${category};
+  cfg = config.${namespace}.${type}.${category};
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable styling using the ${category} framework.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/styling/stylix.nix
+++ b/modules/home/styling/stylix.nix
@@ -6,19 +6,20 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "stylix";
   type = "styling";
 in
 {
-  options.${type}.${category} = with types; {
+  options.${namespace}.${type}.${category} = with types; {
     enable = mkOption {
       description = "Whether to enable styling using the ${category} category.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };
 
-  config.${category} = mkIf config.${type}.${category}.enable {
+  config.${category} = mkIf config.${namespace}.${type}.${category}.enable {
 
     enable = mkDefault true;
     autoEnable = mkDefault true;

--- a/modules/home/wm/default.nix
+++ b/modules/home/wm/default.nix
@@ -1,5 +1,6 @@
 { inputs, ... }:
 let
+  namespace = "self";
   module = "wm";
 in
 {
@@ -10,7 +11,7 @@ in
     }:
     with lib;
     {
-      options.${module} = with types; {
+      options.${namespace}.${module} = with types; {
         enable = mkOption {
           description = "Whether to enabled window managers and their configs";
           default = false;

--- a/modules/home/wm/hyprland/default.nix
+++ b/modules/home/wm/hyprland/default.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   program = "hyprland";
-  cfg = config.${type}.${program};
+  cfg = config.${namespace}.${type}.${program};
 in
 {
-  options.${type}.${program} = with types; {
+  options.${namespace}.${type}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.enable;
+      default = config.${namespace}.${type}.enable;
       type = bool;
     };
   };

--- a/modules/home/wm/hyprland/hyprpaper.nix
+++ b/modules/home/wm/hyprland/hyprpaper.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   program = "hyprpaper";
-  cfg = config.${type}.${program};
+  cfg = config.${namespace}.${type}.${program};
 in
 {
-  options.${type}.${program} = with types; {
+  options.${namespace}.${type}.${program} = with types; {
     enable = mkOption {
       description = "Whether to enable ${program}'s default config.";
-      default = config.${type}.hyprland.enable;
+      default = config.${namespace}.${type}.hyprland.enable;
       type = bool;
     };
   };

--- a/modules/home/wm/hyprland/monitors.nix
+++ b/modules/home/wm/hyprland/monitors.nix
@@ -5,9 +5,10 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "wm";
   program = "hyprland";
-  cfg = config.${category}.${program};
+  cfg = config.${namespace}.${category}.${program};
 in
 {
   config.wayland.windowManager.${program}.settings = mkIf cfg.enable {
@@ -42,7 +43,7 @@ in
             in
             "${adapter}, ${resolution}, ${position}, ${scale} # ${name}";
       in
-      (mapAttrsToList monitorToString config.${category}.monitors)
+      (mapAttrsToList monitorToString config.${namespace}.${category}.monitors)
       ++ [ ", preferred, auto, 1 # Catch all" ];
   };
 }

--- a/modules/home/wm/hyprland/shortcuts.nix
+++ b/modules/home/wm/hyprland/shortcuts.nix
@@ -5,9 +5,10 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "wm";
   program = "hyprland";
-  cfg = config.${category}.${program};
+  cfg = config.${namespace}.${category}.${program};
 in
 {
   config.wayland.windowManager.${program}.settings = mkIf cfg.enable {
@@ -33,6 +34,6 @@ in
             in
             "${modifier}, ${instance.key}, ${instance.action.hyprland} # ${description}";
       in
-      mapAttrsToList shortcutToString config.${category}.shortcuts;
+      mapAttrsToList shortcutToString config.${namespace}.${category}.shortcuts;
   };
 }

--- a/modules/home/wm/hyprland/workspaces.nix
+++ b/modules/home/wm/hyprland/workspaces.nix
@@ -5,9 +5,10 @@
 }:
 with lib;
 let
+  namespace = "self";
   category = "wm";
   program = "hyprland";
-  cfg = config.${category}.${program};
+  cfg = config.${namespace}.${category}.${program};
 in
 {
   config.wayland.windowManager.${program}.settings = mkIf cfg.enable {
@@ -27,6 +28,6 @@ in
             in
             "${order}, ${name}, ${primary}, ${persistent}, ${monitor} # ${description}";
       in
-      mapAttrsToList workspaceToString config.${category}.workspaces;
+      mapAttrsToList workspaceToString config.${namespace}.${category}.workspaces;
   };
 }

--- a/modules/home/wm/monitors.nix
+++ b/modules/home/wm/monitors.nix
@@ -5,12 +5,13 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   category = "monitors";
-  cfg = config.${type}.${category};
+  cfg = config.${namespace}.${type}.${category};
 in
 {
-  options.${type} = with types; {
+  options.${namespace}.${type} = with types; {
     ${category} = mkOption {
       description = "Set of monitors this system has.";
       default = { };

--- a/modules/home/wm/shortcuts/application-management.nix
+++ b/modules/home/wm/shortcuts/application-management.nix
@@ -6,11 +6,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   category = "shortcuts";
 in
 {
-  config.${type}.${category} = with pkgs; {
+  config.${namespace}.${type}.${category} = with pkgs; {
 
     # open applications
 

--- a/modules/home/wm/shortcuts/audio-and-brightness.nix
+++ b/modules/home/wm/shortcuts/audio-and-brightness.nix
@@ -5,11 +5,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   category = "shortcuts";
 in
 {
-  config.${type}.${category} = with pkgs; {
+  config.${namespace}.${type}.${category} = with pkgs; {
     #
     #  Enables support for special function keys:
     #

--- a/modules/home/wm/shortcuts/focus-and-workspaces.nix
+++ b/modules/home/wm/shortcuts/focus-and-workspaces.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   category = "shortcuts";
 in
 {
-  config.${type}.${category} =
+  config.${namespace}.${type}.${category} =
     with builtins;
     let
-      workspaceNames = attrNames config.${type}.workspaces;
-      filterWorkspaces = filter (name: config.${type}.workspaces.${name}.enable);
+      workspaceNames = attrNames config.${namespace}.${type}.workspaces;
+      filterWorkspaces = filter (name: config.${namespace}.${type}.workspaces.${name}.enable);
       enabledWorkspaces = filterWorkspaces workspaceNames;
       amountOfWorkspaces = length enabledWorkspaces;
 

--- a/modules/home/wm/shortcuts/options.nix
+++ b/modules/home/wm/shortcuts/options.nix
@@ -5,12 +5,13 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   category = "shortcuts";
-  cfg = config.${type}.${category};
+  cfg = config.${namespace}.${type}.${category};
 in
 {
-  options.${type} = with types; {
+  options.${namespace}.${type} = with types; {
     ${category} = mkOption {
       description = "Set of shortcuts each window manager has.";
 

--- a/modules/home/wm/shortcuts/screen-shots.nix
+++ b/modules/home/wm/shortcuts/screen-shots.nix
@@ -5,11 +5,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   category = "shortcuts";
 in
 {
-  config.${type}.${category} = with pkgs; {
+  config.${namespace}.${type}.${category} = with pkgs; {
     #
     #  Screen shot keyboard shortcuts follow the MacOS key bindings:
     #

--- a/modules/home/wm/shortcuts/session-management.nix
+++ b/modules/home/wm/shortcuts/session-management.nix
@@ -5,11 +5,12 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   category = "shortcuts";
 in
 {
-  config.${type}.${category} = with pkgs; {
+  config.${namespace}.${type}.${category} = with pkgs; {
     #
     #  This is for key bindings that do session management. Things such as:
     #
@@ -22,7 +23,7 @@ in
       super = true;
       shift = true;
       key = "c";
-      action.hyprland = " exec, hyprctl reload";
+      action.hyprland = "exec, hyprctl reload";
       action.i3 = "reload";
     };
 

--- a/modules/home/wm/workspaces.nix
+++ b/modules/home/wm/workspaces.nix
@@ -5,12 +5,13 @@
 }:
 with lib;
 let
+  namespace = "self";
   type = "wm";
   category = "workspaces";
-  cfg = config.${type}.${category};
+  cfg = config.${namespace}.${type}.${category};
 in
 {
-  options.${type} = with types; {
+  options.${namespace}.${type} = with types; {
     ${category} = mkOption {
       description = "The workspaces a window-manager should have";
 
@@ -29,34 +30,35 @@ in
         submodule (
           { name, ... }:
           {
+            options = {
 
-            options.enable = mkOption {
-              description = "Adapter name to place this monitor relative to.";
-              default = true;
-              example = false;
-              type = bool;
+              enable = mkOption {
+                description = "Adapter name to place this monitor relative to.";
+                default = true;
+                example = false;
+                type = bool;
+              };
+
+              name = mkOption {
+                description = "The name this workspace will have when displayed some where.";
+                example = "Terminal";
+                default = name;
+                type = str;
+              };
+
+              order = mkOption {
+                description = "The order in which they should appear in respect to each other.";
+                example = 1;
+                type = int;
+              };
+
+              display = mkOption {
+                description = "The name of the adapter this workspace will be displayed onto.";
+                example = "eDP-1";
+                default = null;
+                type = nullOr str;
+              };
             };
-
-            options.name = mkOption {
-              description = "The name this workspace will have when displayed some where.";
-              example = "Terminal";
-              default = name;
-              type = str;
-            };
-
-            options.order = mkOption {
-              description = "The order in which they should appear in respect to each other.";
-              example = 1;
-              type = int;
-            };
-
-            options.display = mkOption {
-              description = "The name of the adapter this workspace will be displayed onto.";
-              example = "eDP-1";
-              default = null;
-              type = nullOr str;
-            };
-
           }
         )
       );

--- a/modules/nixos/all/default.nix
+++ b/modules/nixos/all/default.nix
@@ -1,0 +1,38 @@
+{ inputs, ... }:
+let
+  namespace = "self";
+  module = "all";
+in
+{
+  flake.nixosModules.${module} =
+    {
+      config,
+      lib,
+      ...
+    }:
+    with lib;
+    let
+      cfg = config.${namespace}.${module};
+    in
+    {
+      options.${namespace}.${module} = with types; {
+        enable = mkOption {
+          description = "Whether to enable all modules under the self namespace.";
+          default = false;
+          type = bool;
+        };
+      };
+
+      config.${namespace} = mkIf cfg.enable {
+        defaults.enable = mkDefault true;
+        nas.enable = mkDefault true;
+        qmk.enable = mkDefault true;
+      };
+
+      imports = with inputs.self.nixosModules; [
+        defaults
+        nas
+        qmk
+      ];
+    };
+}

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [
+    ./all
     ./defaults
     ./nas
     ./qmk

--- a/modules/nixos/defaults/auto-upgrade.nix
+++ b/modules/nixos/defaults/auto-upgrade.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "auto-upgrade";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to this module.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       type = bool;
     };
   };

--- a/modules/nixos/defaults/boot.nix
+++ b/modules/nixos/defaults/boot.nix
@@ -6,15 +6,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "boot";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to this module.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       type = bool;
     };
   };

--- a/modules/nixos/defaults/default.nix
+++ b/modules/nixos/defaults/default.nix
@@ -1,5 +1,6 @@
 { inputs, ... }:
 let
+  namespace = "self";
   module = "defaults";
 in
 {
@@ -10,11 +11,10 @@ in
     }:
     with lib;
     {
-      options.${module} = with types; {
+      options.${namespace}.${module} = with types; {
         enable = mkOption {
           description = "Whether to load the defaults for all systems.";
-          default = true;
-          readOnly = true;
+          default = false;
           type = bool;
         };
       };

--- a/modules/nixos/defaults/fonts.nix
+++ b/modules/nixos/defaults/fonts.nix
@@ -6,15 +6,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "fonts";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to install common fonts like open-dyslexic.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       type = bool;
     };
   };

--- a/modules/nixos/defaults/locale.nix
+++ b/modules/nixos/defaults/locale.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "locale";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to use the default locale I use.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       readOnly = true;
       type = bool;
     };

--- a/modules/nixos/defaults/networking.nix
+++ b/modules/nixos/defaults/networking.nix
@@ -6,15 +6,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "networking";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to use the default networking settings.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       readOnly = true;
       type = bool;
     };

--- a/modules/nixos/defaults/nix.config.nix
+++ b/modules/nixos/defaults/nix.config.nix
@@ -6,15 +6,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "nix";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to fill in a bunch of defaults regarding nix and nixpkgs.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       readOnly = true;
       type = bool;
     };

--- a/modules/nixos/defaults/programs.nix
+++ b/modules/nixos/defaults/programs.nix
@@ -6,15 +6,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "programs";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to fill in a bunch of defaults programs.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       readOnly = true;
       type = bool;
     };

--- a/modules/nixos/defaults/secrets.nix
+++ b/modules/nixos/defaults/secrets.nix
@@ -7,15 +7,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "secrets";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to load the defaults secrets.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       type = bool;
     };
   };

--- a/modules/nixos/defaults/security.nix
+++ b/modules/nixos/defaults/security.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "security";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to load the default security settings.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       type = bool;
     };
 

--- a/modules/nixos/defaults/services.nix
+++ b/modules/nixos/defaults/services.nix
@@ -5,15 +5,16 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "services";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to load the default services.";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       type = bool;
     };
   };

--- a/modules/nixos/defaults/user.nix
+++ b/modules/nixos/defaults/user.nix
@@ -9,18 +9,19 @@
 }:
 with lib;
 let
+  namespace = "self";
   module = "defaults";
   submodule = "main-user";
-  cfg = config.${module}.${submodule};
+  cfg = config.${namespace}.${module}.${submodule};
 in
 {
 
   imports = [ inputs.home-manager.nixosModules.home-manager ];
 
-  options.${module}.${submodule} = with types; {
+  options.${namespace}.${module}.${submodule} = with types; {
     enable = mkOption {
       description = "Whether to enable the main user (me).";
-      default = config.${module}.enable;
+      default = config.${namespace}.${module}.enable;
       readOnly = true;
       type = bool;
     };
@@ -40,39 +41,41 @@ in
     };
   };
 
-  config.users.mutableUsers = mkDefault false;
+  config.users = mkIf cfg.enable {
+    mutableUsers = mkDefault false;
 
-  config.users.users.${cfg.username} = mkIf cfg.enable {
-    uid = mkDefault 1000;
-    description = mkDefault cfg.description;
-    home = mkDefault "/home/${cfg.username}";
+    users.${cfg.username} = {
+      uid = mkDefault 1000;
+      description = mkDefault cfg.description;
+      home = mkDefault "/home/${cfg.username}";
 
-    enable = mkDefault true;
-    isNormalUser = mkDefault true;
-    createHome = mkDefault true;
-    linger = mkDefault true;
+      enable = mkDefault true;
+      isNormalUser = mkDefault true;
+      createHome = mkDefault true;
+      linger = mkDefault true;
 
-    hashedPasswordFile =
-      mkDefault
-        config.sops.secrets."hosts/${config.networking.hostName}/password".path;
+      hashedPasswordFile =
+        mkDefault
+          config.sops.secrets."hosts/${config.networking.hostName}/password".path;
 
-    extraGroups = [
-      "wheel" # sudo
-      "networkmanager" # NetworkManager control
-      "adm" # read system logs
-      "input" # raw input devices
-      "uinput" # virtual input devices
-      "dialout" # serial devices (USB, Arduino, etc.)
-      "video" # GPU / video devices
-      "audio" # sound devices
-      "camera" # webcam access (if present on your system)
-      "lp" # printers
-      "scanner" # scanners
-    ];
+      extraGroups = [
+        "wheel" # sudo
+        "networkmanager" # NetworkManager control
+        "adm" # read system logs
+        "input" # raw input devices
+        "uinput" # virtual input devices
+        "dialout" # serial devices (USB, Arduino, etc.)
+        "video" # GPU / video devices
+        "audio" # sound devices
+        "camera" # webcam access (if present on your system)
+        "lp" # printers
+        "scanner" # scanners
+      ];
 
-    openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvSu8xkYJQX2br3EHxNADY7byEzRAXlc+Z8X+vbwuRd tygo@thinkpad"
-    ];
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvSu8xkYJQX2br3EHxNADY7byEzRAXlc+Z8X+vbwuRd tygo@thinkpad"
+      ];
+    };
   };
 
   config.home-manager = mkIf cfg.enable {
@@ -87,10 +90,7 @@ in
       { ... }:
       {
         imports = [
-          inputs.self.homeModules.cli
-          inputs.self.homeModules.gui
-          inputs.self.homeModules.styling
-          inputs.self.homeModules.wm
+          inputs.self.homeModules.all
           (CONFIG_PATH + "/home.nix")
         ];
       };

--- a/modules/nixos/nas/default.nix
+++ b/modules/nixos/nas/default.nix
@@ -1,5 +1,6 @@
 _:
 let
+  namespace = "self";
   module = "nas";
 in
 {
@@ -11,13 +12,13 @@ in
     }:
     with lib;
     let
-      cfg = config.${module};
+      cfg = config.${namespace}.${module};
     in
     {
-      options.${module} = with types; {
+      options.${namespace}.${module} = with types; {
         enable = mkOption {
           description = "Whether to mount my NAS to your system.";
-          default = true;
+          default = false;
           type = bool;
         };
       };
@@ -40,9 +41,14 @@ in
               "noauto"
               "users"
               "user"
-              "uid=${toString config.users.users.${config.defaults.main-user.username}.uid}"
               "gid=0"
-            ];
+            ]
+            ++ (
+              if (config.self.defaults.main-user.enable or false) then
+                [ "uid=${toString config.users.users.${config.self.defaults.main-user.username}.uid}" ]
+              else
+                warn "The setting config.self.defaults.main-user is not enabled." [ ]
+            );
           };
         in
         mkIf cfg.enable {

--- a/modules/nixos/qmk/default.nix
+++ b/modules/nixos/qmk/default.nix
@@ -1,5 +1,6 @@
 _:
 let
+  namespace = "self";
   module = "qmk";
 in
 {
@@ -7,14 +8,15 @@ in
     {
       config,
       lib,
+      pkgs,
       ...
     }:
     with lib;
     let
-      cfg = config.${module};
+      cfg = config.${namespace}.${module};
     in
     {
-      options.${module} = with types; {
+      options.${namespace}.${module} = with types; {
         enable = mkOption {
           description = "Whether to make the system capable of flashing QMK firmware.";
           default = false;


### PR DESCRIPTION
This will make refactoring later easier, it prevents collisions, and more importantly, it makes it easier to see what options are mine.

<!-- ^ Please summarise the changes you have made and explain why they are necessary above here ^ -->

## Checklist

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Made sure my pull request fits [CONTRIBUTING.md].
- [x] Marked commits with `!` if they were breaking changes.
- [x] Updated the `docs/` when needed.
- [x] Added tests to `test/` for all new code.
- [x] This pull request does not fix a security issue. (See [SECURITY.md])

## Meta data

Built on platform (select all applicable):

- [x] Linux (x86_64)
- [ ] Linux (aarch64)
- [ ] Macos (x86_64)
- [ ] Macos (aarch64)
- [ ] other: ...

______________________________________________________________________

Add a :+1: [reaction] to [pull requests you find important].

[contributing.md]: https://github.com/Tygo-van-den-Hurk/NixOS/blob/master/CONTRIBUTING.md
[pull requests you find important]: https://github.com/Tygo-van-den-Hurk/NixOS/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[security.md]: https://github.com/Tygo-van-den-Hurk/NixOS/blob/master/SECURITY.md
